### PR TITLE
garage: plan for 3-node replicated cluster (draft, not applied)

### DIFF
--- a/kubernetes/apps/garage-system/garage/app/crd.yaml
+++ b/kubernetes/apps/garage-system/garage/app/crd.yaml
@@ -1,0 +1,48 @@
+---
+# Garage's [kubernetes_discovery] peer-discovery CRD, applied here (with
+# skip_crd = true in configuration.toml) so garage's own ServiceAccount doesn't
+# need cluster-wide customresourcedefinitions RBAC to create/patch it itself.
+# Source: https://github.com/deuxfleurs-org/garage/blob/v2.3.0/script/k8s/crd/garagenodes.deuxfleurs.fr.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: garagenodes.deuxfleurs.fr
+spec:
+  conversion:
+    strategy: None
+  group: deuxfleurs.fr
+  names:
+    kind: GarageNode
+    listKind: GarageNodeList
+    plural: garagenodes
+    singular: garagenode
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Auto-generated derived type for Node via `CustomResource`
+          properties:
+            spec:
+              properties:
+                address:
+                  format: ip
+                  type: string
+                hostname:
+                  type: string
+                port:
+                  format: uint16
+                  minimum: 0
+                  type: integer
+              required:
+                - address
+                - hostname
+                - port
+              type: object
+          required:
+            - spec
+          title: GarageNode
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/kubernetes/apps/garage-system/garage/app/data-pv.yaml
+++ b/kubernetes/apps/garage-system/garage/app/data-pv.yaml
@@ -1,0 +1,65 @@
+---
+# Static per-replica NFS PersistentVolumes for Garage's object data. NFS volumes
+# don't get per-ordinal templating the way StatefulSet volumeClaimTemplates give
+# Ceph PVCs (see the "meta" volumeClaimTemplate in helmrelease.yaml) — each of
+# these is pre-bound via claimRef to the specific PVC name that ordinal's
+# volumeClaimTemplate will generate (data-garage-0/1/2), so each pod deterministically
+# gets its own NFS export instead of accidentally sharing one.
+#
+# garage-0 reuses the existing /garage export (already holds all current live
+# data — no migration needed for this volume). garage-1/garage-2 are new, empty
+# exports on a different NFS volume (more free space); Garage's own replication
+# will populate them once the 3-node layout is applied.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: garage-data-0
+spec:
+  capacity:
+    storage: 248Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  nfs:
+    server: nas.internal
+    path: /garage
+  claimRef:
+    name: data-garage-0
+    namespace: garage-system
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: garage-data-1
+spec:
+  capacity:
+    storage: 200Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  nfs:
+    server: nas.internal
+    path: /garage-1
+  claimRef:
+    name: data-garage-1
+    namespace: garage-system
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: garage-data-2
+spec:
+  capacity:
+    storage: 200Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  nfs:
+    server: nas.internal
+    path: /garage-2
+  claimRef:
+    name: data-garage-2
+    namespace: garage-system

--- a/kubernetes/apps/garage-system/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/garage-system/garage/app/helmrelease.yaml
@@ -105,6 +105,8 @@ spec:
             protocol: TCP
     serviceMonitor:
       app:
+        service:
+          identifier: app
         endpoints:
           - port: admin
             path: /metrics

--- a/kubernetes/apps/garage-system/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/garage-system/garage/app/helmrelease.yaml
@@ -10,11 +10,28 @@ spec:
     name: garage
   interval: 1h
   values:
+    global:
+      createDefaultServiceAccount: false
     controllers:
       garage:
         type: statefulset
+        replicas: 3
         annotations:
           reloader.stakater.com/auto: "true"
+        statefulset:
+          # Governing headless Service for stable per-pod DNS (garage-0.garage-headless...),
+          # used for RPC peer discovery instead of a hardcoded rpc_public_addr.
+          serviceName:
+            identifier: headless
+          volumeClaimTemplates:
+            - name: meta
+              size: 20Gi
+              accessMode: ReadWriteOnce
+              storageClass: ceph-block
+              globalMounts:
+                - path: /meta
+        serviceAccount:
+          identifier: garage
         containers:
           app:
             image:
@@ -23,6 +40,10 @@ spec:
             env:
               RUST_LOG: "garage=debug"
               TZ: America/New_York
+              # Used to give each replica's shared-NFS data dir its own subPath (see persistence.data below).
+              POD_NAME:
+                fieldRef:
+                  fieldPath: metadata.name
             envFrom:
               - secretRef:
                   name: garage-secret
@@ -58,6 +79,7 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
     defaultPodOptions:
+      automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -67,11 +89,20 @@ spec:
         seccompProfile: { type: RuntimeDefault }
     service:
       app:
+        # Keep the existing Service name so the HTTPRoute backendRef below doesn't break
+        # now that a second (headless) Service is being added.
+        forceRename: garage
         ports:
           s3:
             port: &port 3900
           admin:
             port: 3903
+      headless:
+        clusterIP: None
+        ports:
+          rpc:
+            port: 3901
+            protocol: TCP
     serviceMonitor:
       app:
         endpoints:
@@ -103,11 +134,22 @@ spec:
             metadata_auto_snapshot_interval = "6h"
             metadata_snapshots_dir = "/data/garage-meta-snapshots"
 
-            replication_factor = 1
+            replication_factor = 3
+            consistency_mode = "consistent"
             compression_level = 2
 
             rpc_bind_addr = "[::]:3901"
-            rpc_public_addr = "127.0.0.1:3901"
+            # No static rpc_public_addr: it can't be pod-specific in a single shared
+            # ConfigMap mounted by all 3 replicas. Instead, filter autodiscovery (via
+            # kubernetes_discovery below) to the cluster's pod CIDR.
+            rpc_public_addr_subnet = "10.42.0.0/16"
+
+            [kubernetes_discovery]
+            namespace = "garage-system"
+            service_name = "garage"
+            # CRD is Flux-managed (see crd.yaml) so garage's ServiceAccount doesn't need
+            # cluster-wide customresourcedefinitions RBAC, only verbs on garagenodes itself.
+            skip_crd = true
 
             [s3_api]
             s3_region = "us-east-1"
@@ -130,8 +172,11 @@ spec:
         server: nas.internal
         path: /garage
         globalMounts:
+          # Same NFS export shared by all 3 replicas, but each pod gets its own
+          # subdirectory so they don't write into each other's data blocks.
           - path: /data
-      meta:
-        existingClaim: "{{ .Release.Name }}"
+            subPathExpr: "$(POD_NAME)"
       tmp:
         type: emptyDir
+    serviceAccount:
+      garage: {}

--- a/kubernetes/apps/garage-system/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/garage-system/garage/app/helmrelease.yaml
@@ -30,6 +30,21 @@ spec:
               storageClass: ceph-block
               globalMounts:
                 - path: /meta
+            - name: data
+              # 200Gi request matches the smaller of the 3 static PVs (garage-1/garage-2,
+              # 200Gi each on the multimedia NFS volume with 1.26Ti free) — garage-0's PV
+              # (248Gi, its existing /garage export, 159Gi free today) has more headroom
+              # than this ever requests, which is fine (a PVC only needs request <= PV
+              # capacity, not equal). storageClass: "" means don't dynamically provision;
+              # bind to the pre-created static PV in data-pv.yaml instead, matched by
+              # claimRef per ordinal (data-garage-0/1/2). This whole NFS-static-PV setup
+              # is a stopgap: the QNAP is near capacity, expect to redo this once the
+              # planned Unifi UNAS Pro 4 migration lands.
+              size: 200Gi
+              accessMode: ReadWriteMany
+              storageClass: ""
+              globalMounts:
+                - path: /data
         serviceAccount:
           identifier: garage
         containers:
@@ -40,10 +55,6 @@ spec:
             env:
               RUST_LOG: "garage=debug"
               TZ: America/New_York
-              # Used to give each replica's shared-NFS data dir its own subPath (see persistence.data below).
-              POD_NAME:
-                fieldRef:
-                  fieldPath: metadata.name
             envFrom:
               - secretRef:
                   name: garage-secret
@@ -169,15 +180,6 @@ spec:
           - path: /etc/garage.toml
             subPath: configuration.toml
             readOnly: true
-      data:
-        type: nfs
-        server: nas.internal
-        path: /garage
-        globalMounts:
-          # Same NFS export shared by all 3 replicas, but each pod gets its own
-          # subdirectory so they don't write into each other's data blocks.
-          - path: /data
-            subPathExpr: "$(POD_NAME)"
       tmp:
         type: emptyDir
     serviceAccount:

--- a/kubernetes/apps/garage-system/garage/app/kustomization.yaml
+++ b/kubernetes/apps/garage-system/garage/app/kustomization.yaml
@@ -3,7 +3,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./crd.yaml
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/garage-system/garage/app/kustomization.yaml
+++ b/kubernetes/apps/garage-system/garage/app/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./rbac.yaml
+  - ./replicationsource.yaml
+  - ./volsync-externalsecret.yaml

--- a/kubernetes/apps/garage-system/garage/app/kustomization.yaml
+++ b/kubernetes/apps/garage-system/garage/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./crd.yaml
+  - ./data-pv.yaml
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/garage-system/garage/app/rbac.yaml
+++ b/kubernetes/apps/garage-system/garage/app/rbac.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: &app garage
+  namespace: garage-system # keep
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+rules:
+  - apiGroups:
+      - deuxfleurs.fr
+    resources:
+      - garagenodes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: &app garage
+  namespace: garage-system # keep
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: *app
+subjects:
+  - kind: ServiceAccount
+    name: *app
+    namespace: garage-system # keep

--- a/kubernetes/apps/garage-system/garage/app/replicationsource.yaml
+++ b/kubernetes/apps/garage-system/garage/app/replicationsource.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.dmfrey.com/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: garage
+spec:
+  # Only meta-garage-0 is backed up (belt-and-suspenders insurance), not all 3
+  # per-replica meta PVCs. With replication_factor=3, the normal recovery path
+  # for a corrupted/lost node's metadata is now to evict it from the layout and
+  # let it resync a fresh copy from the other 2 healthy replicas, not restore
+  # from Kopia. Keeping the same ReplicationSource name ("garage") preserves
+  # the existing Kopia source identity/history (garage@garage-system:/data)
+  # from before this migration.
+  sourcePVC: meta-garage-0
+  trigger:
+    schedule: "0 * * * *"
+  kopia:
+    accessModes:
+      - ReadWriteOnce
+    compression: zstd-fastest
+    copyMethod: Snapshot
+    moverAffinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/created-by: volsync
+              topologyKey: kubernetes.io/hostname
+    moverResources:
+      requests:
+        cpu: 100m
+        memory: 2Gi
+      limits:
+        cpu: 500m
+        memory: 8Gi
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    parallelism: 2
+    repository: garage-volsync-secret
+    retain:
+      hourly: 24
+      daily: 7
+    storageClassName: ceph-block-ext4
+    volumeSnapshotClassName: csi-ceph-blockpool

--- a/kubernetes/apps/garage-system/garage/app/volsync-externalsecret.yaml
+++ b/kubernetes/apps/garage-system/garage/app/volsync-externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.dmfrey.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garage-volsync
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: garage-volsync-secret
+    template:
+      data:
+        KOPIA_FS_PATH: /repository
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+        KOPIA_REPOSITORY: filesystem:///repository
+  dataFrom:
+    - extract:
+        key: volsync-template

--- a/kubernetes/apps/garage-system/garage/ks.yaml
+++ b/kubernetes/apps/garage-system/garage/ks.yaml
@@ -5,8 +5,11 @@ kind: Kustomization
 metadata:
   name: garage
 spec:
-  components:
-    - ../../../../components/volsync
+  # NOTE: components/volsync was dropped here. It assumed a single existingClaim
+  # PVC named after the release ("garage"), which no longer matches: the meta
+  # volume is now a per-replica StatefulSet volumeClaimTemplate, so Kubernetes
+  # names the 3 PVCs meta-garage-0/1/2 instead. See the PR description for the
+  # open decision on what (if anything) should back up these PVCs going forward.
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -17,10 +20,6 @@ spec:
   #     namespace: garage-system
   interval: 1h
   path: "./kubernetes/apps/garage-system/garage/app"
-  postBuild:
-    substitute:
-      APP: garage
-      VOLSYNC_CAPACITY: 20Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/garage-system/garage/ks.yaml
+++ b/kubernetes/apps/garage-system/garage/ks.yaml
@@ -8,8 +8,10 @@ spec:
   # NOTE: components/volsync was dropped here. It assumed a single existingClaim
   # PVC named after the release ("garage"), which no longer matches: the meta
   # volume is now a per-replica StatefulSet volumeClaimTemplate, so Kubernetes
-  # names the 3 PVCs meta-garage-0/1/2 instead. See the PR description for the
-  # open decision on what (if anything) should back up these PVCs going forward.
+  # names the 3 PVCs meta-garage-0/1/2 instead. Only meta-garage-0 is backed up,
+  # via a standalone ReplicationSource in app/ (not the shared component, since
+  # its pvc.yaml/bootstrap-restore pattern assumes a single app-wide PVC that
+  # doesn't apply here) — see app/replicationsource.yaml.
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph


### PR DESCRIPTION
## Why

On 2026-07-23 Garage (the shared S3 backend for CNPG WAL archiving and other app backups) suffered a real incident: a Ceph RBD hiccup made its single metadata volume read-only, and the recovery attempt (deleting the pod to force a remount) triggered a second RBD error mid-write that corrupted its LMDB metadata database. It was recovered from a Kopia snapshot, but the incident exposed that Garage has zero redundancy: `replication_factor=1`, one replica, one shared metadata volume.

This PR is **a plan for review, not a live change** — I have no cluster access and haven't applied anything. It grows Garage from single-node to a genuine 3-node replicated cluster. The human (you) decides whether to proceed and runs the manual bootstrap steps below yourselves after merging.

## What changed

`kubernetes/apps/garage-system/garage/app/helmrelease.yaml`:
- `replicas: 3` on the StatefulSet controller.
- Metadata volume (`/meta`) becomes a proper per-replica `statefulset.volumeClaimTemplates` entry (20Gi, `ceph-block`, RWO) instead of the single shared `existingClaim`. Kubernetes will provision `meta-garage-0/1/2` automatically.
- **Data volume design changed (2026-07-25 update): 3 separate NFS exports, not one shared export with `subPathExpr`.** The NAS is near capacity, and with `replication_factor=3` every node holds a full copy — 3-way replicating into one shared export/quota would have used ~3x the current data size against a pool that doesn't have that much free space, and wouldn't have given real failure-domain independence anyway (same RAID array, same NAS, same SPOF). `garage`/`garage-1`/`garage-2` are now 3 independent NFS exports: `garage-0` reuses the existing `/garage` export as-is (already holds all live data, no migration needed for this volume), `garage-1`/`garage-2` are new empty exports on a separate NFS volume with more free space, populated automatically by Garage's own replication once the layout is applied. This is a stopgap — a Unifi UNAS Pro 4 migration is planned in a few weeks and this will likely get redone then.
- `replication_factor` bumped `1 → 3` (confirmed against upstream docs: RF=3 with 3 zones gives every node a full copy and is the documented "safest and most available" configuration for a 3-node cluster). Added `consistency_mode = "consistent"` explicitly.
- Removed the hardcoded `rpc_public_addr = "127.0.0.1:3901"` — this was already broken for anything beyond a single node, since it's baked into one ConfigMap shared by all 3 pods (a single ConfigMap can't hold 3 different per-pod addresses). Replaced with `rpc_public_addr_subnet = "10.42.0.0/16"` (the cluster's pod CIDR, confirmed from `talos/machineconfig.yaml.j2` and the Cilium HelmRelease), which is upstream's documented mechanism for filtering autodiscovery to the right subnet when no static address is set.
- Added `[kubernetes_discovery]` (`namespace = "garage-system"`, `service_name = "garage"`, `skip_crd = true`) so the 3 pods find each other via Garage's built-in Kubernetes peer-discovery feature — confirmed already compiled into the `v2.3.0` binary from your startup logs, just unconfigured until now. **Verified not affected by a known same-node networking bug**: this cluster previously had a Cilium DSR same-node hairpin bug (root-caused 2026-07-10, fixed via `socketLB.hostNamespaceOnly: false` in `kubernetes/apps/kube-system/cilium/app/helmrelease.yaml` — confirmed still live today) that broke same-node ClusterIP connections (that's why DragonflyDB instances needed a podAntiAffinity-vs-garage workaround, since removed). Two different traffic paths here, both fine: (1) Garage→Kubernetes-API calls for peer discovery go through the same `kubernetes.default.svc` ClusterIP category the fix already covers; (2) Garage↔Garage RPC (port 3901) goes through the new *headless* Service, which does direct pod-IP DNS resolution with no ClusterIP/NAT/DSR translation at all — structurally can't hit that bug class regardless of node placement.
- Added a headless Service (`clusterIP: None`) so the StatefulSet gets stable per-pod DNS, referenced via `statefulset.serviceName.identifier`. Had to add `forceRename: garage` to the existing `app` Service so it keeps its current name now that there are two Service entries — otherwise the existing HTTPRoute (`s3.dmfrey.com`) would silently start pointing at a Service that no longer exists.
- Added an explicit `serviceAccount: garage` + `global.createDefaultServiceAccount: false`, mirroring the pattern already used by `apps/self-hosted/homepage`.

`kubernetes/apps/garage-system/garage/app/rbac.yaml` (new) and `crd.yaml` (new):
- Garage's `kubernetes_discovery` needs to read/write `GarageNode` custom resources (group `deuxfleurs.fr`, namespaced). Upstream's own Helm chart grants this via a broad `ClusterRole` that also lets Garage create/patch *any* CustomResourceDefinition in the cluster (needed only because their chart auto-creates the CRD via `skip_crd=false`).
- Instead: `skip_crd = true`, and the CRD is Flux-managed here as a normal manifest (`crd.yaml`, copied from [upstream](https://github.com/deuxfleurs-org/garage/blob/v2.3.0/script/k8s/crd/garagenodes.deuxfleurs.fr.yaml)). RBAC (`rbac.yaml`) is then a namespaced `Role`/`RoleBinding` granting only verbs on `garagenodes` itself — no cluster-wide CRD-management permission needed. Narrower blast radius for a shared homelab cluster.

`kubernetes/apps/garage-system/garage/app/data-pv.yaml` (new):
- 3 static `PersistentVolume` manifests, one per NFS export (`/garage`, `/garage-1`, `/garage-2`), each pre-bound via `claimRef` to the specific per-ordinal PVC name its `volumeClaimTemplates` entry will generate (`data-garage-0`/`data-garage-1`/`data-garage-2`). NFS doesn't get per-ordinal templating the way Ceph PVCs do via `volumeClaimTemplates` + a `StorageClass` — this static-PV-with-`claimRef` pattern is the standard workaround. The `data` `volumeClaimTemplates` entry in `helmrelease.yaml` requests 200Gi (matching the smaller of the 3 PVs) with `storageClass: ""` so it binds to these instead of dynamically provisioning against `ceph-block`.

`kubernetes/apps/garage-system/garage/ks.yaml`:
- Dropped `components/volsync` and its `APP`/`VOLSYNC_CAPACITY` substitutions. That component assumes a single PVC named after the release (`garage`) — it doesn't hold once `/meta` becomes 3 separately-named per-replica PVCs.

`kubernetes/apps/garage-system/garage/app/replicationsource.yaml` (new) and `volsync-externalsecret.yaml` (new):
- **Backup decision resolved: option (b).** Only `meta-garage-0` is backed up, as belt-and-suspenders insurance — with `replication_factor=3`, the normal recovery path for a corrupted/lost node's metadata is now to evict it from the layout and let it resync a fresh copy from the other 2 healthy replicas, not restore from Kopia. Standalone manifests rather than the shared `components/volsync` component, since that component's `pvc.yaml`/bootstrap-restore pattern assumes a single app-wide PVC that doesn't apply here. Kept the `ReplicationSource` named `garage` (not renamed) so it preserves the existing Kopia source identity/history (`garage@garage-system:/data`) from before this migration, rather than starting a fresh backup lineage.

## Manual steps you'll need to run against the live cluster (after merging)

Cluster layout changes are inherently manual/live and Garage warns strongly against scripting `layout apply` unsupervised, so none of this is automated: (**cross-checked against the real docs site**, `garagehq.deuxfleurs.fr` — confirms RF=3 as "the safest and most available mode" for a 3-node cluster, one zone per node, and this exact assign → show → apply sequence, including the same warning against scripting it unsupervised).

**Pre-flight: what's actually affected while Garage is down for the PVC migration.** Garage currently has exactly 4 buckets: `cnpg` (WAL archiving + base backups for 14 CNPG clusters), `dragonflydb` (snapshot backups for 5 Dragonfly instances), `loki` (Loki's live chunk storage), `tempo` (Tempo's live trace storage). Cluster-wide VolSync (every other app's backups) is unaffected — its Kopia repository is on NFS, unrelated infrastructure. The one thing that *does* need pausing first:
```
kubectl patch replicationsource garage -n garage-system --type merge -p '{"spec":{"paused":true}}'
```
(the new `meta-garage-0` backup added by this PR — otherwise its hourly trigger could fire mid-migration against a PVC in a transitional state). Everything else (CNPG WAL archiving, DragonflyDB snapshots, Loki/Tempo ingestion) will fail-and-retry or briefly hiccup during the outage and self-recover once Garage is back up — validated behavior from the 2026-07-23 incident, as long as the snapshot/restore step below stays short. Unsuspend the ReplicationSource once the new cluster is healthy: `kubectl patch replicationsource garage -n garage-system --type merge -p '{"spec":{"paused":false}}'`.

1. **Preserve node-0's existing data before scaling up.** The current single PVC is named `garage`; the new StatefulSet will look for `meta-garage-0` for the first replica. These names don't match, so node-0 won't pick up its existing metadata automatically. Before applying this change:
   - Create a `VolumeSnapshot` of the existing `garage` PVC (a `csi-ceph-blockpool` VolumeSnapshotClass is already used elsewhere in this repo for VolSync), then create a new PVC named `meta-garage-0` (same `ceph-block` StorageClass, 20Gi) with `dataSourceRef` pointing at that snapshot.
   - If snapshotting doesn't work cleanly, the fallback is a one-off `Job` that mounts both the old `garage` PVC and a freshly created `meta-garage-0` PVC and `rsync -a`s the contents across.
   - Once `meta-garage-0` exists with node-0's data, reconcile this change — the StatefulSet will adopt it for ordinal 0; ordinals 1 and 2 get fresh empty PVCs from the template.
2. Reconcile in the usual order (source → kustomization → helmrelease) per this repo's `CLAUDE.md`.
3. Confirm the 3 pods come up and register themselves as `GarageNode` CRs: `kubectl -n garage-system get garagenodes`.
4. Run `garage status` from any pod (`kubectl exec -n garage-system garage-0 -- /garage status`) — the 2 new nodes should show up with `NO ROLE ASSIGNED`.
5. Assign each node a zone/capacity/tag and apply the layout (one node per zone so RF=3 gives one full copy per physical node; capacities match each node's actual static PV — `garage-0` gets more since it's reusing the existing, larger `/garage` export):
   ```
   garage layout assign <node-0-id> -z k8s-0 -c 248G -t garage-0
   garage layout assign <node-1-id> -z k8s-1 -c 200G -t garage-1
   garage layout assign <node-2-id> -z k8s-2 -c 200G -t garage-2
   garage layout show      # review before applying
   garage layout apply --version <N>   # call exactly once
   ```
6. Watch `garage status` / the `garage_layout_*` metrics until nodes 1 and 2 finish syncing a full copy of existing data from node 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQ5Sb7Ld3fa3vmVTaYr8fM)_






